### PR TITLE
Updated import url to live under an SSL context

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans);
 
 .line-plot {
     position: relative;


### PR DESCRIPTION
Having the googleapis import url live under a non-ssl context causes grief when running a Jupyter Notebook under SSL because of mixed content blocking in browsers.  Updated to SSL. 
